### PR TITLE
Django 1.10 compatibility

### DIFF
--- a/treebeard/admin.py
+++ b/treebeard/admin.py
@@ -3,7 +3,7 @@
 import sys
 
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from django.contrib import admin, messages
 from django.http import HttpResponse, HttpResponseBadRequest


### PR DESCRIPTION
Remove unused import of patterns that is removed in Django 1.10 (https://docs.djangoproject.com/en/1.10/releases/1.10/#removed-features-1-10)
